### PR TITLE
WIP: Make all domain indicies link targets

### DIFF
--- a/sphinx/directives/other.py
+++ b/sphinx/directives/other.py
@@ -79,11 +79,18 @@ class TocTree(SphinxDirective):
         return ret
 
     def parse_content(self, toctree: addnodes.toctree) -> list[Node]:
+        indices: set[str] = set()
+        for domain in self.env.domains.values():
+            if not domain.indices:
+                continue
+            for idx in domain.indices:
+                indices.add(idx.name)
+
         generated_docnames = frozenset(self.env.domains['std']._virtual_doc_names)
         suffixes = self.config.source_suffix
 
         # glob target documents
-        all_docnames = self.env.found_docs.copy() | generated_docnames
+        all_docnames = self.env.found_docs.copy() | indices | generated_docnames
         all_docnames.remove(self.env.docname)  # remove current document
 
         ret: list[Node] = []


### PR DESCRIPTION
Instead of populating the std domain _virtual_doc_names during initialization, iterate through all domains and add all index names as virtual documents.

The goal is to make it possible for docsets to reference indicies with the toctree directive.

Subject: <short purpose of this pull request>

### Feature or Bugfix
<!-- please choose -->
- Feature
- Bugfix
- Refactoring

### Purpose
- <long purpose of this pull request>
- <Environment if this PR depends on>

### Detail
- <feature1 or bug1>
- <feature2 or bug2>

### Relates
- <URL or Ticket>

